### PR TITLE
Add is_dummy column to users table

### DIFF
--- a/database/migrations/2023_05_30_090517_add_is_dummy_column_to_users_table.php
+++ b/database/migrations/2023_05_30_090517_add_is_dummy_column_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_dummy')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['is_dummy']);
+        });
+    }
+};


### PR DESCRIPTION
This PR adds a new column "is_dummy" to the users table. The column is a boolean value that indicates whether the user is a dummy user or not. This feature is needed for a new functionality that is being developed.

The changes are straightforward and do not affect the functionality of the application. However, please note that this will affect the database. Once merged, please run `php artisan migrate` to update the database with the new column.

Additionally, I have backed up the data for the users table. If you need to restore the data after the migration, please contact me and I will assist you.

Please review and merge. Thank you!